### PR TITLE
feat: Add a Kubernetes CronJob to run the pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Configuration
 
 * `RETIREMENT_EDX_OAUTH2_CLIENT_ID` (default `"retirement_service_worker"`)
 * `RETIREMENT_COOL_OFF_DAYS` (default `30`)
+* `RETIREMENT_K8S_CRONJOB_SCHEDULE` (default `"0 0 * * *"`, once a day at 
+  midnight)
 
 These values can be modified with `tutor config save --set
 PARAM_NAME=VALUE` commands.

--- a/tutorretirement/patches/k8s-jobs
+++ b/tutorretirement/patches/k8s-jobs
@@ -1,0 +1,19 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: retirement-job
+  labels:
+    app.kubernetes.io/component: cronjob
+spec:
+  schedule: {{ RETIREMENT_K8S_CRONJOB_SCHEDULE }}
+  jobTemplate:
+    spec:
+      containers:
+        - name: retirement
+          image: {{ RETIREMENT_DOCKER_IMAGE }}
+          command:
+            - bash
+            - run_retirement_pipeline.sh
+            - {{ RETIREMENT_COOL_OFF_DAYS }}
+        restartPolicy: OnFailure

--- a/tutorretirement/plugin.py
+++ b/tutorretirement/plugin.py
@@ -21,6 +21,7 @@ config = {
         "EDX_OAUTH2_CLIENT_ID": "retirement_service_worker",
         "COOL_OFF_DAYS": 30,
         "TUBULAR_VERSION": "{{ OPENEDX_COMMON_VERSION }}",
+        "K8S_CRONJOB_SCHEDULE": "0 0 * * *",
     },
 }
 


### PR DESCRIPTION
Add a CronJob to k8s that runs the retirement pipeline based on
the schedule defined in the `K8S_CRONJOB_SCHEDULE` configuration
parameter.