### PR TITLE
fix: Correct definition for Kubernetes CronJob

### DIFF
--- a/tutorretirement/patches/k8s-jobs
+++ b/tutorretirement/patches/k8s-jobs
@@ -6,14 +6,16 @@ metadata:
   labels:
     app.kubernetes.io/component: cronjob
 spec:
-  schedule: {{ RETIREMENT_K8S_CRONJOB_SCHEDULE }}
+  schedule: '{{ RETIREMENT_K8S_CRONJOB_SCHEDULE }}'
   jobTemplate:
     spec:
-      containers:
-        - name: retirement
-          image: {{ RETIREMENT_DOCKER_IMAGE }}
-          command:
-            - bash
-            - run_retirement_pipeline.sh
-            - {{ RETIREMENT_COOL_OFF_DAYS }}
-        restartPolicy: OnFailure
+      template:
+        spec:
+          containers:
+            - name: retirement
+              image: {{ RETIREMENT_DOCKER_IMAGE }}
+              command:
+                - bash
+                - run_retirement_pipeline.sh
+                - {{ RETIREMENT_COOL_OFF_DAYS }}
+          restartPolicy: OnFailure


### PR DESCRIPTION
* A `jobTemplate` needs a `spec` that references a `template` with another `spec`. Correct that syntax.
* The CronJob `schedule` need not necessarily be quoted, but it probably doesn't hurt and the documentation does recommend the quotes.

Reference:
https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/