### PR TITLE
fix: Quote command array for CronJob

### DIFF
--- a/tutorretirement/patches/k8s-jobs
+++ b/tutorretirement/patches/k8s-jobs
@@ -15,7 +15,7 @@ spec:
             - name: retirement
               image: {{ RETIREMENT_DOCKER_IMAGE }}
               command:
-                - bash
-                - run_retirement_pipeline.sh
-                - {{ RETIREMENT_COOL_OFF_DAYS }}
+                - 'bash'
+                - 'run_retirement_pipeline.sh'
+                - '{{ RETIREMENT_COOL_OFF_DAYS }}'
           restartPolicy: OnFailure


### PR DESCRIPTION
Kubernetes expects a `container`'s `command` property to be an array of strings, and won't cast `RETIREMENT_COOL_OFF_DAYS` (which is an integer) to a string.

Thus, quote the integer variable, and to be on the safe side also quote the other components of the command.