### PR TITLE
fix: Make bash script report failure

### DIFF
--- a/tutorretirement/patches/k8s-jobs
+++ b/tutorretirement/patches/k8s-jobs
@@ -16,6 +16,7 @@ spec:
               image: {{ RETIREMENT_DOCKER_IMAGE }}
               command:
                 - 'bash'
+                - '-e'
                 - 'run_retirement_pipeline.sh'
                 - '{{ RETIREMENT_COOL_OFF_DAYS }}'
               volumeMounts:

--- a/tutorretirement/plugin.py
+++ b/tutorretirement/plugin.py
@@ -44,7 +44,7 @@ def retire_users(context):
     cool_off_days = config["RETIREMENT_COOL_OFF_DAYS"]
     job_runner.run_job(
         service="retirement",
-        command=f"bash run_retirement_pipeline.sh {cool_off_days}"
+        command=f"bash -e run_retirement_pipeline.sh {cool_off_days}"
     )
 
 


### PR DESCRIPTION
Add "-e" flag to the bash commands in local and k8s so that the script
reports non-zero status if any of the python scripts fail.