### PR TITLE
feat: Enable setting history limits for the Kubernetes CronJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,17 @@ invoke this command from a cron job on your host.
 For a Kubernetes deployment, this plugin defines a [CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) 
 which runs the retirement pipeline according to the schedule defined in 
 the `RETIREMENT_K8S_CRONJOB_SCHEDULE` configuration parameter.
+You can also tweak the [history
+limits](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits)
+for the CronJob.
 
 Configuration
 -------------
 
 * `RETIREMENT_EDX_OAUTH2_CLIENT_ID` (default `"retirement_service_worker"`)
 * `RETIREMENT_COOL_OFF_DAYS` (default `30`)
+* `RETIREMENT_K8S_CRONJOB_HISTORYLIMIT_FAILURE` (default `1`)
+* `RETIREMENT_K8S_CRONJOB_HISTORYLIMIT_SUCCESS` (default `3`)
 * `RETIREMENT_K8S_CRONJOB_SCHEDULE` (default `"0 0 * * *"`, once a day at 
   midnight)
 

--- a/tutorretirement/patches/k8s-jobs
+++ b/tutorretirement/patches/k8s-jobs
@@ -6,7 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/component: cronjob
 spec:
+  failedJobsHistoryLimit: {{ RETIREMENT_K8S_CRONJOB_HISTORYLIMIT_FAILURE }}
   schedule: '{{ RETIREMENT_K8S_CRONJOB_SCHEDULE }}'
+  successfulJobsHistoryLimit: {{ RETIREMENT_K8S_CRONJOB_HISTORYLIMIT_SUCCESS }}
   jobTemplate:
     spec:
       template:

--- a/tutorretirement/plugin.py
+++ b/tutorretirement/plugin.py
@@ -21,6 +21,8 @@ config = {
         "EDX_OAUTH2_CLIENT_ID": "retirement_service_worker",
         "COOL_OFF_DAYS": 30,
         "TUBULAR_VERSION": "{{ OPENEDX_COMMON_VERSION }}",
+        "K8S_CRONJOB_HISTORYLIMIT_FAILURE": 1,
+        "K8S_CRONJOB_HISTORYLIMIT_SUCCESS": 3,
         "K8S_CRONJOB_SCHEDULE": "0 0 * * *",
     },
 }


### PR DESCRIPTION
By default, a Kubernetes cluster keeps a record of the 3 most recent successful and the 1 most recent failed instance of a CronJob.

For the retirement pipeline (which normally runs daily) it may be wise to retain a record of maybe the last 7, or even the last 30 runs.

Thus, introduce two new configuration parameters:

* `RETIREMENT_K8S_CRONJOB_HISTORYLIMIT_FAILURE` (default 1)
* `RETIREMENT_K8S_CRONJOB_HISTORYLIMIT_SUCCESS` (default 3)

... and set the CronJob's `failedJobsHistoryLimit` and `successfulJobsHistoryLimit` properties accordingly.

Reference:
https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/