### PR TITLE
build: Version 1.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 tag = True
 sign_tags = True
 message = build: Version {new_version}
-current_version = 0.1.0
+current_version = 1.0.0
 
 [bumpversion:file:CHANGELOG.md]
 search = Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## Version 1.0.0 (2022-08-09)
 
 * [BREAKING CHANGE] Support Tutor 14 and Open edX Nutmeg. This entails
   a configuration format change from JSON to YAML, meaning that from

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ appropriate one:
 Installation
 ------------
 
-    pip install git+https://github.com/hastexo/tutor-contrib-retirement@v0.1.0
+    pip install git+https://github.com/hastexo/tutor-contrib-retirement@v1.0.0
 
 Usage
 -----


### PR DESCRIPTION
As of this release, the plugin supports Tutor v14 and hence Open edX Nutmeg.