### PR TITLE
fix: Bump the Tutor version dependency to >=16.1.4

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,5 +1,6 @@
 [general]
 contrib=contrib-title-conventional-commits
+regex-style-search=true
 
 # When invoked as just "gitlint" without any other arguments, Gitlint
 # processes the most recent commit message *unless* it's being fed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* [Enhancement] Support the Open edX `palm.3` release. Drop
+  compatibility with Open edX Olive.
+
 ## Version 2.1.0 (2023-08-23)
 
 * [Enhancement] Support Tutor 16 and Open edX Palm, Python 3.10, and Python 3.11.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ appropriate one:
 | Maple            | `>=13.2, <14`[^1] | `maple`       | 0.1.x          |
 | Nutmeg           | `>=14.0, <15`     | `nutmeg`      | 1.x.x          |
 | Olive            | `>=15.0, <16`     | `main`        | 2.x.x          |
-| Palm             | `>=16.0, <17`     | `main`        | 2.x.x          |
+| Palm             | `>=16.0, <17`     | `main`        | 3.x.x          |
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
 ￼   later. That is because this plugin uses the Tutor v1 plugin API,

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor <17, >=15.0.0"],
+    install_requires=["tutor <17, >=16.1.4"],
     setup_requires=["setuptools-scm"],
     entry_points={
         "tutor.plugin.v1": [


### PR DESCRIPTION
 We rely on the Tutor `OPENEDX_COMMON_VERSION` variable to determine the tag (or branch) to fetch for the Tubular repository.
    
In Tutor 16.1.4, the default value for `OPENEDX_COMMON_VERSION` changed from `open-release/palm.2` to `open-release/palm.3`. This means we now need a version bump in our own `install_requires` list, so that we require Tutor>=16.1.4.
    
Since this breaks compatibility with Open edX Olive (and will thus require a major release bump on our part), update the README accordingly.

Reference: https://github.com/overhangio/tutor/pull/923