### PR TITLE
fix: Bump the Tutor version dependency to >=16.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Support the Open edX `palm.4` release.
+
 ## Version 3.0.0 (2023-10-25)
 
 * [Enhancement] Support the Open edX `palm.3` release. Drop

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor <17, >=16.1.4"],
+    install_requires=["tutor <17, >=16.1.7"],
     setup_requires=["setuptools-scm"],
     entry_points={
         "tutor.plugin.v1": [


### PR DESCRIPTION
We rely on the Tutor `OPENEDX_COMMON_VERSION` variable to determine the tag (or branch) to fetch for the Tubular repository.

In Tutor 16.1.6, the default value for `OPENEDX_COMMON_VERSION` changed from `open-release/palm.3` to `open-release/palm.4`. This means we now need a version bump in our own `install_requires` list, so that we require Tutor>=16.1.6.

However, the Tutor 16.1.6 package as published to PyPI contains a bug that makes it uninstallable, so we have to require Tutor>=16.1.7 instead.
    
References:
https://github.com/overhangio/tutor/releases/tag/v16.1.6
https://github.com/overhangio/tutor/issues/943
