### PR TITLE
fix: Drop support for retiring E-Commerce Service accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* [Bug fix] Drop support for retiring users in the [Open edX E-Commerce Service](https://github.com/openedx/ecommerce).
+  Per the discussion in [Issue #36](https://github.com/hastexo/tutor-contrib-retirement/issues/36), account retirement for the E-Commerce Service "will never" work and "has never" worked, thus this is not a breaking change.
+
 ## Version 3.3.0 (2024-04-05)
 
 * [Enhancement] Support Python 3.12.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ appropriate one:
 ￼   [which was introduced with that
 ￼   release](https://github.com/overhangio/tutor/blob/master/CHANGELOG.md#v1320-2022-04-24).
 
+
+Limitations
+------------
+
+This plugin cannot be used for retiring accounts in the [Open edX E-Commerce Service](https://github.com/openedx/ecommerce).[^ecom]
+
+[^ecom]: See [Issue #36](https://github.com/hastexo/tutor-contrib-retirement/issues/36) in this repository for a related discussion of missing functionality in E-Commerce account retirement.
+
+
 Installation
 ------------
 

--- a/tutorretirement/templates/retirement/build/retirement/pipeline_config/config.yml
+++ b/tutorretirement/templates/retirement/build/retirement/pipeline_config/config.yml
@@ -3,13 +3,11 @@ client_secret: {{ RETIREMENT_EDX_OAUTH2_CLIENT_SECRET }}
 
 base_urls:
     lms: {{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}
-    {% if ECOMMERCE_HOST is defined %}ecommerce: {{ "https" if ENABLE_HTTPS else "http" }}://{{ ECOMMERCE_HOST }}{% endif %}
     {% if DISCOVERY_HOST is defined %}discovery: {{ "https" if ENABLE_HTTPS else "http" }}://{{ DISCOVERY_HOST }}{% endif %}
     {% if NOTES_HOST is defined %}notes: {{ "https" if ENABLE_HTTPS else "http" }}://{{ NOTES_HOST }}{% endif %}
 
 retirement_pipeline:
     {% if FORUM_VERSION is defined %}- [ 'RETIRING_FORUMS', 'FORUMS_COMPLETE', 'LMS', 'retirement_retire_forum' ]{% endif %}
-    {% if ECOMMERCE_HOST is defined %}- [ 'RETIRING_ECOMMERCE', 'ECOMMERCE_COMPLETE', 'ECOMMERCE', 'retire_learner' ]{% endif %}
     {% if DISCOVERY_HOST is defined %}- [ 'RETIRING_DISCOVERY', 'DISCOVERY_COMPLETE', 'DISCOVERY', 'replace_usernames' ]{% endif %}
     {% if NOTES_HOST is defined %}- [ 'RETIRING_NOTES', 'NOTES_COMPLETE', 'LMS', 'retirement_retire_notes' ]{% endif %}
     - [ 'RETIRING_EMAIL_LISTS', 'EMAIL_LISTS_COMPLETE', 'LMS', 'retirement_retire_mailings' ]


### PR DESCRIPTION
This never worked, and can't ever work, due to limitations in the E-Commerce service itself.

Thus, rather than rely on whether `ECOMMERCE_HOST` is defined to decide whether the retirement pipeline for that service should be enabled, always disable it.

Also, update the README explaining that this plugin can't be used to retire E-Commerce accounts.

Fixes #36.
