### PR TITLE
chore: Drop Python 3.8 support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.8
           - 3.9
           - "3.10"
           - 3.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* Drop support for Python 3.8.
+
+When updating your plugin to this version, you'll need to rebuild the image.
+
 ## Version 4.0.0 (2024-08-06)
 
 * [BREAKING CHANGE] Add support for Tutor 18 and Open edX Redwood.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ appropriate one:
 | Olive            | `>=15.0, <16`     | `quince`      | 2.x.x          |
 | Palm             | `>=16.0, <17`     | `quince`      | 3.x.x          |
 | Quince           | `>=17.0, <18`     | `quince`      | 3.x.x          |
-| Redwood          | `>=18.0, <19`     | `main`        | 4.x.x          |
+| Redwood          | `>=18.0, <19`     | `main`        | 5.x.x          |
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
 ￼   later. That is because this plugin uses the Tutor v1 plugin API,

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     long_description_content_type='text/markdown',
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=["tutor <19, >=16.1.7"],
     setup_requires=["setuptools-scm"],
     entry_points={
@@ -39,7 +39,6 @@ setup(
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = gitlint,py{38,39,310,311,312},flake8
+envlist = gitlint,py{39,310,311,312},flake8
 
 [gh-actions]
 python =
-    3.8: gitlint,py38,flake8
     3.9: gitlint,py39,flake8
     3.10: gitlint,py310,flake8
     3.11: gitlint,py311,flake8

--- a/tutorretirement/templates/retirement/build/retirement/Dockerfile
+++ b/tutorretirement/templates/retirement/build/retirement/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.11
 ENV PYTHONUNBUFFERED 1
 RUN python3 -m venv /retirement/venv/
 ENV PATH "/retirement/venv/bin:$PATH"


### PR DESCRIPTION
Python 3.8 will end security support on 2024-10-31; drop support for Python 3.8 in this plugin.