### PR TITLE
feat: Allow to override the base image for builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Allow to override the Dockerfile base image.
+
 ## Version 5.1.0 (2025-01-03)
 
 * [Enhancement] Support Tutor 19 and Open edX Sumac.

--- a/tutorretirement/plugin.py
+++ b/tutorretirement/plugin.py
@@ -17,6 +17,7 @@ config = {
     },
     "defaults": {
         "VERSION": __version__,
+        "BASE_IMAGE": "docker.io/python:3.11",
         "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}retirement:{{ RETIREMENT_VERSION }}",  # noqa: E501
         "EDX_OAUTH2_CLIENT_ID": "retirement_service_worker",
         "COOL_OFF_DAYS": 30,

--- a/tutorretirement/templates/retirement/build/retirement/Dockerfile
+++ b/tutorretirement/templates/retirement/build/retirement/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM {{ RETIREMENT_BASE_IMAGE }}
 ENV PYTHONUNBUFFERED 1
 RUN python3 -m venv /retirement/venv/
 ENV PATH "/retirement/venv/bin:$PATH"


### PR DESCRIPTION
Add a config option `RETIREMENT_BASE_IMAGE` that allows to override the base image for builds.