### PR TITLE
Add agentic coding guidelines

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec tox -e gitlint -- --staged --msg-filename "$1" run-hook

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,2 +1,5 @@
-#!/bin/sh
-exec tox -e flake8
+#!/bin/sh -e
+
+git diff-index --check --cached HEAD --
+
+tox -e flake8

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ __pycache__
 .idea
 .python-version
 .tox
-tests/tutor-sandbox/config.yml
+tests/tutor-sandbox

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".agents/skills"]
+	path = .agents/skills
+	url = ../skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md — terse agent index (routing + gotchas)
+
+Agents: explore the repo directly; this file routes, it does not teach.
+
+See [HACKING.md](HACKING.md) for contributor information, style guide, and tests.
+
+**IMPORTANT:** When invoking any agent on this repository, you MUST run the following commands **immediately** upon evaluation of this file, before doing anything else:
+```shell
+git submodule update --init
+git config core.hooksPath .githooks
+```
+
+## Session memory
+
+Write plans, notes, and ephemeral files to `.ai/` (gitignored).
+Prefer `.ai/tmp/` over the system temp directory.
+
+## When planning
+
+Read these to understand dependencies and tooling:
+
+- `setup.py`
+- `tox.ini`
+
+## Tooling
+
+### Tests
+
+Entry point is **`tox`**.
+
+## Changelog
+
+- Proposed changes to the [CHANGELOG.md](CHANGELOG.md) file must be under the `Unreleased` heading.
+- Do not retroactively change information about previously released versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## Version 5.4.2 (2026-06-02)
 
 * [Chore] Create a new patch release for a convenient `ulmo.3` upgrade.

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,11 +1,27 @@
-Developer notes
-===============
+# Developer notes
 
 This document is for people who maintain and contribute to this
 repository.
 
-Commit messages
----------------
+## Style guide
+
+### Python
+
+For Python code, follow [PEP 8](https://peps.python.org/pep-0008/).
+
+### Markdown
+
+For Markdown documentation,
+
+* adhere to the [CommonMark specification](https://spec.commonmark.org/),
+* use [ATX](https://spec.commonmark.org/current/#atx-headings) instead of [setext](https://spec.commonmark.org/0.31.2/#setext-heading) headings,
+* use [fenced](https://spec.commonmark.org/current/#fenced-code-blocks) rather than [indented](https://spec.commonmark.org/current/#indented-code-block) code blocks,
+* identify the language of each fenced code block with an [info string](https://spec.commonmark.org/current/#info-string),
+* preserve existing [bullet list markers](https://spec.commonmark.org/current/#bullet-list-marker),
+* write [one sentence per line](https://sive.rs/1s):
+  ensure that every line of free-flow text outside code blocks contains exactly one English sentence.
+
+## Commit messages
 
 Commit messages follow the [Conventional
 Commits](https://www.conventionalcommits.org/) format that is also
@@ -18,8 +34,7 @@ prefixes](https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep
 to be used in commit messages via
 [Gitlint](https://jorisroovers.com/gitlint/).
 
-How to run tests
-----------------
+## How to run tests
 
 This repo uses [tox](https://tox.readthedocs.io/) for unit and
 integration tests. It does not install `tox` for you, you should
@@ -43,13 +58,7 @@ In addition, we use [GitHub
 Actions](https://docs.github.com/en/actions) to run the same checks
 on every push to GitHub.
 
-*If you absolutely must,* you can use the `--no-verify` flag to `git
-commit` and `git push` to bypass local checks, and rely on GitHub
-Actions alone. But doing so is strongly discouraged.
-
-
-How to cut a release
---------------------
+## How to cut a release
 
 This repository uses
 [bumpversion](https://pypi.org/project/bumpversion/) for managing new

--- a/README.md
+++ b/README.md
@@ -1,19 +1,14 @@
-User Retirement Tutor plugin
-===================================
+# User Retirement Tutor plugin
 
 This is an **experimental** plugin for
-[Tutor](https://docs.tutor.overhang.io) that enables the [user retirement 
-feature](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/user_retire/index.html) in Open edX.
+[Tutor](https://docs.tutor.overhang.io) that enables the [user retirement feature](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/user_retire/index.html) in Open edX.
 
 This repository was previously hosted under the `hastexo` GitHub organization, and moved to `cleura` in December 2025 as part of a routine repository consolidation.
 
-Version compatibility matrix
-----------------------------
-￼
-You must install a supported release of this plugin to match the Open
-edX and Tutor version you are deploying. If you are installing this
-plugin from a branch in this Git repository, you must select the
-appropriate one:
+## Version compatibility matrix
+
+You must install a supported release of this plugin to match the Open edX and Tutor version you are deploying.
+If you are installing this plugin from a branch in this Git repository, you must select the appropriate one:
 
 | Open edX release | Tutor version     | Plugin branch | Plugin release |
 |------------------|-------------------|---------------|----------------|
@@ -28,67 +23,59 @@ appropriate one:
 | Teak             | `>=20.0, <21`     | `main`        | `>=5.3`        |
 | Ulmo             | `>=21.0, <22`     | `main`        | `>=5.4`        |
 
-[^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
-￼   later. That is because this plugin uses the Tutor v1 plugin API,
-￼   [which was introduced with that
-￼   release](https://github.com/overhangio/tutor/blob/master/CHANGELOG.md#v1320-2022-04-24).
+[^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or later.
+      That is because this plugin uses the Tutor v1 plugin API, which was introduced with that release.
+      See the [GitHub changelog](https://github.com/overhangio/tutor/blob/master/CHANGELOG.md#v1320-2022-04-24).
 
+## Limitations
 
-Limitations
-------------
-
-This plugin cannot be used for retiring accounts in the [Open edX E-Commerce Service](https://github.com/openedx/ecommerce),[^ecom] nor the [Course Discovery Service](https://github.com/openedx/course-discovery).[^discovery].
+This plugin cannot be used for retiring accounts in the [Open edX E-Commerce Service](https://github.com/openedx/ecommerce),[^ecom] nor the [Course Discovery Service](https://github.com/openedx/course-discovery).[^discovery]
 
 [^ecom]: See [Issue #36](https://github.com/cleura/tutor-contrib-retirement/issues/36) for background.
+
 [^discovery]: See [Issue #39](https://github.com/cleura/tutor-contrib-retirement/issues/39) for background.
 
+## Installation
 
-Installation
-------------
+```shell
+pip install git+https://github.com/cleura/tutor-contrib-retirement@v5.4.2
+```
 
-    pip install git+https://github.com/cleura/tutor-contrib-retirement@v5.4.2
-
-Usage
------
+## Usage
 
 To enable this plugin, run:
 
-    tutor plugins enable retirement
+```shell
+tutor plugins enable retirement
+```
 
 Before starting Tutor, build the docker image:
 
-    tutor images build retirement
+```shell
+tutor images build retirement
+```
 
-After enabling this plugin, you need to restart your Tutor deployment with
-`tutor local quickstart` or `tutor k8s quickstart`. This ensures that the 
-retirement service worker is registered as an OAuth2 client in LMS and that the 
-retirement pipeline stages are correctly populated in LMS.
+After enabling this plugin, you need to restart your Tutor deployment with `tutor local quickstart` or `tutor k8s quickstart`.
+This ensures that the retirement service worker is registered as an OAuth2 client in LMS and that the retirement pipeline stages are correctly populated in LMS.
 
 To run the retirement pipeline in the Tutor local deployment:
 
-    tutor local retire-users
+```shell
+tutor local retire-users
+```
 
-This will start the `retirement-job` service and run the retirement pipeline 
-as described [here](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/user_retire/driver_setup.html).
-If you want to run this command periodically in a local deployment, you can 
-invoke this command from a cron job on your host. 
+This will start the `retirement-job` service and run the retirement pipeline as described [here](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/user_retire/driver_setup.html).
+If you want to run this command periodically in a local deployment, you can invoke this command from a cron job on your host.
 
-For a Kubernetes deployment, this plugin defines a [CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) 
-which runs the retirement pipeline according to the schedule defined in 
-the `RETIREMENT_K8S_CRONJOB_SCHEDULE` configuration parameter.
-You can also tweak the [history
-limits](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits)
-for the CronJob.
+For a Kubernetes deployment, this plugin defines a [CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) which runs the retirement pipeline according to the schedule defined in the `RETIREMENT_K8S_CRONJOB_SCHEDULE` configuration parameter.
+You can also tweak the [history limits](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits) for the CronJob.
 
-Configuration
--------------
+## Configuration
 
 * `RETIREMENT_EDX_OAUTH2_CLIENT_ID` (default `"retirement_service_worker"`)
 * `RETIREMENT_COOL_OFF_DAYS` (default `30`)
 * `RETIREMENT_K8S_CRONJOB_HISTORYLIMIT_FAILURE` (default `1`)
 * `RETIREMENT_K8S_CRONJOB_HISTORYLIMIT_SUCCESS` (default `3`)
-* `RETIREMENT_K8S_CRONJOB_SCHEDULE` (default `"0 0 * * *"`, once a day at 
-  midnight)
+* `RETIREMENT_K8S_CRONJOB_SCHEDULE` (default `"0 0 * * *"`, once a day at midnight)
 
-These values can be modified with `tutor config save --set
-PARAM_NAME=VALUE` commands.
+These values can be modified with `tutor config save --set PARAM_NAME=VALUE` commands.


### PR DESCRIPTION
- **chore: Add all of tests/tutor-sandbox to .gitignore**
  Don't just ignore the config file; ignore the whole sandbox.
  

- **build: Make Git hooks stricter**
  * Extend the pre-commit hook so that it checks for newly introduced
    trailing whitespace before running tox.
  
  * Add a commit-msg hook to check the commit message with gitlint, and
    abort the commit if the commit message is unsatisfactory.
  

- **docs: Improve HACKING.md**
  * Be explicit about PEP 8.
  * Change from setext to ATX headings.
  * Remove references to git --no-verify.
  * Add Markdown style guide.
  

- **docs: Add AGENTS.md**
  * Add instructions for agentic coding assistants.
  * Add submodule to contain agentic coding assistant skills.
  